### PR TITLE
Allow creating a cluster based on IP addresses

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,10 @@ if (is_true ${ERLANG_NODE}); then
     export ERLANG_NODE="ejabberd@${nodename}"
 fi
 
+if is_true "${ERLANG_NODE_USE_IP}"; then
+  export ERLANG_NODE="ejabberd@$(hostname -i)"
+  echo "Setting ERLANG_NODE from IP: ${ERLANG_NODE}"
+fi
 
 run_scripts() {
     local run_script_dir="${EJABBERD_HOME}/scripts/${1}"

--- a/scripts/post/40_join_cluster.sh
+++ b/scripts/post/40_join_cluster.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+source "${EJABBERD_HOME}/scripts/lib/base_config.sh"
+source "${EJABBERD_HOME}/scripts/lib/config.sh"
+source "${EJABBERD_HOME}/scripts/lib/base_functions.sh"
+source "${EJABBERD_HOME}/scripts/lib/functions.sh"
+
+get_cluster_ip_from_dns() {
+    local cluster_ip=$( \
+        /usr/local/bin/elixir -e ":inet_res.lookup('${EJABBERD_CLUSTER_DNS_NAME}', :in, :a) |> Enum.map(fn {a,b,c,d} -> IO.puts(\"#{a}.#{b}.#{c}.#{d}\") end)" \
+        | grep -v ${HOSTIP} \
+        | head -1)
+    echo "${cluster_ip}"
+}
+
+
+file_exist ${FIRST_START_DONE_FILE} \
+    && exit 0
+
+is_zero ${EJABBERD_CLUSTER_DNS_NAME} \
+    && exit 0
+
+cluster_ip=$(get_cluster_ip_from_dns)
+
+if [ -n "$cluster_ip" ]; then
+    echo "Found other IP ${cluster_ip} for cluster ${EJABBERD_CLUSTER_DNS_NAME}, attempting to join"
+    join_cluster "${cluster_ip}"
+else
+    echo "No other IP found for cluster ${EJABBERD_CLUSTER_DNS_NAME}, assuming I'm the master"
+fi
+
+exit 0

--- a/scripts/pre/10_erlang_cookie.sh
+++ b/scripts/pre/10_erlang_cookie.sh
@@ -10,7 +10,7 @@ source "${EJABBERD_HOME}/scripts/lib/functions.sh"
 set_erlang_cookie() {
     echo "Set erlang cookie to ${ERLANG_COOKIE}..."
     echo ${ERLANG_COOKIE} > ${ERLANGCOOKIEFILE}
-    chmod 400 ${ERLANGCOOKIEFILE}
+    chmod 600 ${ERLANGCOOKIEFILE}
 }
 
 


### PR DESCRIPTION
New environment variables:
- `ERLANG_NODE_USE_IP`: set to true to name nodes "ejabberd@<a.b.c.d>"
- `EJABBERD_CLUSTER_DNS_NAME`: set this to a DNS name that resolves to the IPs of the cluster nodes (e.g. `tasks.ejabberd` for Docker Swarm)